### PR TITLE
Update FFFingerPrinter.js

### DIFF
--- a/lib/FFFingerPrinter.js
+++ b/lib/FFFingerPrinter.js
@@ -449,7 +449,7 @@ class FFFingerPrinter {
         sample_fmt: s.sample_fmt,
         sample_rate: s.sample_rate,
         channels: s.channels,
-        channel_layout: s.channel_layout,
+        channel_layout: s.channel_layout || '',
         bit_rate: s.bit_rate || 0
       });
     } else if (stream.codec_type === 'video') {


### PR DESCRIPTION
Some audio codes like wmav2 has no channel_layout attribute.